### PR TITLE
yrdsb.ca is York Region District School Board

### DIFF
--- a/lib/domains/ca/yrdsb.txt
+++ b/lib/domains/ca/yrdsb.txt
@@ -1,1 +1,1 @@
-Thornhill Secondary School
+York Region District School Board


### PR DESCRIPTION
A simple visit to yrdsb.ca reveals that it is the York Region District School Board instead of just Thornhill Secondary School (which is in the YRDSB).